### PR TITLE
Update README.md with new Segmentation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The recognition process also produces the segmentation, called hypseg in Sphinx 
 ```javascript
 var seg = new Module.Segmentation();
 if (recognizer.getHypseg(seg) == Module.ReturnType.SUCCESS) {
-    for (var i = 0 ; i < seg.size ; i++) {
+    for (var i = 0 ; i < seg.size(); i++) {
         var segItem = seg.get(i);
         console.log("Word " + segItem.word +
                     " starts at frame " + segItem.start +


### PR DESCRIPTION
Hi, I noticed that the segmentation API in the readme was outdated - specifically, `segmentation.length` and `segmentation.at` don't work. The correct usage, `segmentation.size` and `segmentation.get`, is in `tests.js`. To avoid future confusion I updated the readme slightly :)
