### PR TITLE
Direct HTTPS links to demos, link fix, typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
           <h1>
 	    <a name="welcome-to-pocketsphinxjs" class="anchor" href="#welcome-to-pocketsphinxjs"><span class="octicon octicon-link"></span></a>Welcome to Pocketsphinx.js</h1>
 	  
-	  <p>Pocketsphinx.js is a speech recognition library written entirely in JavaScript and running entirely in the web browser. It does not require flash or any browser plug-in and does not do any server-side processing. It makes use of <a href="https://github.com/kripken/emscripten">Emscripten</a> to convert <a href="http://cmusphinx.sourceforge.net/">PocketSphinx</a>, an open-source speech recognizer written in C, into JavaScript. Audio is recorded with the getUserMedia JavaScript API and processed through the Web Audio API.</p>
+	  <p>Pocketsphinx.js is a speech recognition library written entirely in JavaScript and running entirely in the web browser. It does not require Flash or any browser plug-in and does not do any server-side processing. It makes use of <a href="https://github.com/kripken/emscripten">Emscripten</a> to convert <a href="http://cmusphinx.sourceforge.net/">PocketSphinx</a>, an open-source speech recognizer written in C, into JavaScript. Audio is recorded with the getUserMedia JavaScript API and processed through the Web Audio API.</p>
 
 	  <h1>
 	    <a name="current-status" class="anchor" href="#current-status"><span class="octicon octicon-link"></span></a>Features</h1>
@@ -57,7 +57,7 @@
 	    <li>Works on Chrome and Firefox,</li>
 	    <li>Audio resampling inside a web worker, without loading the UI thread.</li>
 	  </ul>
-	  <p>If you're intersted, take a look at the <a href="https://github.com/syl22-00/pocketsphinx.js/tree/master/doc/AudioRecorder">documentation</a>.</p>
+	  <p>If you're interested, take a look at the <a href="https://github.com/syl22-00/pocketsphinx.js/tree/master/doc/AudioRecorder">documentation</a>.</p>
 
 
 	  <h1>
@@ -67,7 +67,7 @@
 	  <p>Using the library for real-time recognition implies using bleeding-edge Web technologies that really are just emerging. A general introduction of these technologies and their current status can be found in this <a href="https://github.com/syl22-00/TechDocs/blob/master/AudioInBrowser.md">overview of audio in the browser.</a></p>
 	  <h1>
 	    <a name="live-demo" class="anchor" href="#live-demo"><span class="octicon octicon-link"></span></a>Live demo</h1>
-	  <p>There is a live demo <a href="live-demo.html">here</a>, one in mandarin Chinese <a href="live-demo-chinese.html">here</a>, and a demo of <a href="live-demo-chinese.html">keyword spotting</a>. It works on Chrome and Firefox as live audio capture uses parts of the Web Audio API that are currently only available in these browsers.</p>
+	  <p>There is a live demo <a href="live-demo.html">here</a>, one in mandarin Chinese <a href="live-demo-chinese.html">here</a>, and a demo of <a href="live-demo-kws.html">keyword spotting</a>. It works on Chrome and Firefox as live audio capture uses parts of the Web Audio API that are currently only available in these browsers.</p>
 
 	  <h1>License</h1>
 	  It's open-source (MIT license, with PocketSphinx also under a BSD-style license), and available on <a href="https://github.com/syl22-00/pocketsphinx.js">Github</a>.


### PR DESCRIPTION
- Change demo links to always point to HTTPS, so that it works on Chrome by default
- Keyword spotting demo link fix - it was pointing to Chinese demo
- Fix for minor typos