### PR TITLE
Return scores from each segment

### DIFF
--- a/src/psRecognizer.cpp
+++ b/src/psRecognizer.cpp
@@ -154,14 +154,18 @@ namespace pocketsphinxjs {
     if (decoder == NULL) return BAD_STATE;
     seg.clear();
     int32 sfh=0, efh=0;
+    int32 ascr=0, lscr=0, lback=0;
     std::string hseg;
     ps_seg_t *itor = ps_seg_iter(decoder);
     while (itor) {
       SegItem segItem;
       segItem.word = ps_seg_word(itor);
       ps_seg_frames(itor, &sfh, &efh);
+      ps_seg_prob(itor, &ascr, &lscr, &lback);
       segItem.start = sfh;
       segItem.end = efh;
+      segItem.ascr = ascr;
+      segItem.lscr = lscr;
       seg.push_back(segItem);
       itor = ps_seg_next(itor);
     }

--- a/src/psRecognizer.h
+++ b/src/psRecognizer.h
@@ -50,6 +50,8 @@ namespace pocketsphinxjs {
     std::string word;
     int start;
     int end;
+    int ascr;
+    int lscr;
   };
 
   typedef std::vector<std::string> StringsListType;
@@ -157,7 +159,9 @@ EMSCRIPTEN_BINDINGS(recognizer) {
   emscripten::value_object<ps::SegItem>("SegItem")
     .field("word", &ps::SegItem::word)
     .field("start", &ps::SegItem::start)
-    .field("end", &ps::SegItem::end);
+    .field("end", &ps::SegItem::end)
+    .field("ascr", &ps::SegItem::ascr)
+    .field("lscr", &ps::SegItem::lscr);
 
   emscripten::value_object<ps::Transition>("Transition")
     .field("from", &ps::Transition::from)


### PR DESCRIPTION
Almost all wrappers of pocketsphinx (swig, android) expect the scores to be a part of the result segments.