### PR TITLE
Fix chrome autoplay issue

### DIFF
--- a/webapp/live.html
+++ b/webapp/live.html
@@ -86,8 +86,11 @@
 
       // This starts recording. We first need to get the id of the grammar to use
       var startRecording = function() {
-        var id = document.getElementById('grammars').value;
-        if (recorder && recorder.start(id)) displayRecording(true);
+        // Resume audio context. Chrome can prevent it from starting without a click. 
+        audioContext.resume().then(() => {
+          var id = document.getElementById('grammars').value;
+          if (recorder && recorder.start(id)) displayRecording(true);
+        });
       };
 
       // Stops recording


### PR DESCRIPTION
Chrome autostart policy prevents recording if "Start" is the first click, so resume audio context there as a backup.  Additional context in Issue #148